### PR TITLE
docs: Improve the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,65 +2,86 @@
 
 [![install size](https://packagephobia.com/badge?p=sk-form-data)](https://packagephobia.com/result?p=sk-form-data)
 
-A middleware that automatically parses your SvelteKit form data for Svelte Form Actions
+A middleware that automatically parses your SvelteKit form data for use with [SvelteKit form actions](https://kit.svelte.dev/docs/form-actions).
+
+## Why?
+
+This reduces form validation boilerplate and works great with a schema validation library like [Zod](https://zod.dev/). 
+
+![image](https://user-images.githubusercontent.com/38083522/218318411-5eed31f3-9f58-4a36-97e4-d47bbba0e893.png)
+
+
+## Setup
 
 ### Install
 
-`npm install --save sk-form-data`
+You can use a package manager of your choice but `npm` is used by default.
 
-### Use
+```bash
+npm i sk-form-data
+```
+
+Note to **pnpm** users: **pnpm** doesn't automatically install peer dependencies, so you might have to include `@remix-run/web-file` yourself with `pnpm i @remix-run/web-file`. 
+
+### Add Middleware
+
+Add `form_data` to your other hooks inside `hooks.server.ts`. If you have existing hooks you can use `sequence` from SvelteKit to add more hooks. 
 
 ```typescript
 // hooks.server.ts
+
 import { sequence } from '@sveltejs/kit/hooks'
 import { form_data } from 'sk-form-data'
 
-// Sequence comes from SK and allows you to add many hooks.
-// ie. export const handle = sequence(logging, auth, form_data)
-export const handle: Handle = sequence(form_data)
+export const handle = sequence(form_data)
 ```
 
-Now... all of your actions will have a new property in locals
+### Use Inside Actions
 
-```typescript
-// Any generic server file with Sveltekit form actions being used.
+Your form actions will have a new `form_data` property in `locals`.
+
+```ts
 // +page.server.ts
 
 export const actions = {
 	default: async function ({ locals }) {
-		// locals.form_data
 		console.log(locals.form_data); // whatever you sent from your form
-		// do rest of your stuff
-		...
+		// do rest of your stuff...
 	},
 }
 ```
 
-### Complete Forms Flow
+## Example
+
+Use a form as you would in SvelteKit but keep in mind you can only use the `POST` method.
 
 ```svelte
 <!-- +page.svelte -->
 
-<form use:enhance>
+<script lang="ts">
+	import { enhance } from '$app/forms'
+</script>
+
+<form method="POST" use:enhance>
 	<label for="title">Title: </label>
 	<input name="title" id="title" type="text" value="Scott" />
 </form>
 ```
 
+Inside your form actions you have access to the parsed form data inside `locals.form_data` you can pass to a function that transforms values based on your Zod schema for example.
+
 ```typescript
-// Any generic server file with Sveltekit form actions being used.
 // +page.server.ts
+
 export const actions = {
 	default: async function ({ locals }) {
-		// locals.form_data
-		console.log(locals.form_data); // { title: "Scott" }
-		// do rest of your stuff
-		...
+		console.log(locals.form_data); // whatever you sent from your form
+		// do rest of your stuff...
 	},
 }
 ```
 
-## Support my work
+## Support My Work
 
 https://syntax.fm
 


### PR DESCRIPTION
I wanted to make the readme more friendly, so that you can glance over the important information but be able to copy and paste code to get started which is why I moved the comments outside of the examples and included more information for users that use `pnpm` because I ran into some issues with peer dependencies.

I prefer to have a section on the reasoning behind the package to understand why I would use it but it can be improved or removed if you want.

Thank you for making this! 😄