### PR TITLE
Add Remote Functions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ export const actions = {
 }
 ```
 
+### Use Remote Functins
+
+Inside the Remote Functions use the `getRequestEvent` to get the `locals`, which contain parsed `form_data`.
+
+```ts
+// index.remote.ts
+
+export const createPost = form(async (data) => {
+	const { locals: { form_data } } = getRequestEvent(); // whatever you sent from your form
+	// do rest of your stuff...
+});
+```
+
 ## Example
 
 Use a form as you would in SvelteKit but keep in mind you can only use the `POST` method.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 import { parseFormData } from "parse-nested-form-data";
 export const form_data = async ({ event, resolve }) => {
     // Only look for form data
-    const is_action = event.request.headers.get("content-type") === "application/x-www-form-urlencoded";
+    const is_action = event.request.headers.get("content-type") === "application/x-www-form-urlencoded" || event.isRemoteRequest;
     if (event.request.method === "POST" && is_action) {
         try {
             // Make a clone to prevent error in already read body


### PR DESCRIPTION
Although the Remote Functions functionality is still experimental, I'm using it in some projects already, and I've noticed that the form data isn't getting parsed.
The cause is that remote functions appear to be using multipart encoding by default.

Here is reproduction and a demo of the fix: https://stackblitz.com/edit/sveltejs-kit-template-default-rrygckqt?file=src%2Fhooks.server.js 

I've checked that it doesn't break anything in case Remote Functions are not enabled.
`event.isRemoteRequest` is `false` if the SK version is `>=2.27.0`, otherwise it's `undefined`,
so the check should work as intended.

---

I didn't find any contributing guidelines, so please let me know if I should improve something :)